### PR TITLE
Integrate gutenberg-mobile release v1.106.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,14 +1,4 @@
 ref:
-  # This should have either a commit or tag key.
-  # If both are set, tag will take precedence.
-  #
-  # We have automation that reads and updates this file.
-  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
-  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
-  #
-  # Example:
-  #
-  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
-  tag: v1.106.0
+  commit: v1.106.0
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile


### PR DESCRIPTION
## Description
This PR incorporates the 1.106.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/derekblank/gutenberg-mobile/pull/2

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.